### PR TITLE
TASK-018: Add property P&L report

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,11 +14,13 @@ import InvestmentReportPage from './pages/InvestmentReportPage';
 import TeamPage from './components/TeamPage';
 import { ReportsPage } from './pages/ReportsPage';
 import { TransactionsPage } from './pages/TransactionsPage';
+import { PropertyPLReportPage } from './pages/PropertyPLReportPage';
 
 const router = createHashRouter(
   createRoutesFromElements(
     <>
       <Route path="/reports/investment/:reportId" element={<InvestmentReportPage />} />
+      <Route path="/reports/property-pl/:propertyId" element={<PropertyPLReportPage />} />
       <Route element={<Navigation />}>
         <Route path="/" element={<Navigate to="/properties" replace />} />
         <Route path="/properties" element={<PropertiesPage />} />

--- a/src/components/Reports/PropertyPLReport.tsx
+++ b/src/components/Reports/PropertyPLReport.tsx
@@ -1,0 +1,356 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Paper,
+  Typography,
+  CircularProgress,
+  Button
+} from '@mui/material';
+import { Download as DownloadIcon } from '@mui/icons-material';
+import { format, subMonths, startOfMonth } from 'date-fns';
+import { transactionApi } from '../../services/transactionApi';
+import PropertyService from '../../services/PropertyService';
+import { generatePropertyPLReport, getIncomeCategories, getExpenseCategories } from '../../utils/reportUtils';
+import type { PropertyPLReport as PLReport } from '../../utils/reportUtils';
+
+interface PropertyPLReportProps {
+  propertyId: string;
+  months?: number;
+}
+
+export const PropertyPLReport: React.FC<PropertyPLReportProps> = ({
+  propertyId,
+  months = 6
+}) => {
+  const [report, setReport] = useState<PLReport | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadReport = async () => {
+      try {
+        setLoading(true);
+
+        // Fetch property details and transactions
+        const [property, transactions] = await Promise.all([
+          PropertyService.getPropertyById(propertyId),
+          transactionApi.getByProperty(propertyId)
+        ]);
+
+        // Generate report from transactions
+        const plReport = generatePropertyPLReport(
+          transactions,
+          propertyId,
+          property.address,
+          months
+        );
+
+        setReport(plReport);
+      } catch (err) {
+        console.error('Failed to load report:', err);
+        setError(err instanceof Error ? err.message : 'Failed to load report');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadReport();
+  }, [propertyId, months]);
+
+  const formatCurrency = (amount: number) => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD'
+    }).format(amount);
+  };
+
+  const formatMonth = (monthKey: string) => {
+    const [year, month] = monthKey.split('-');
+    return new Date(parseInt(year), parseInt(month) - 1).toLocaleDateString('en-US', {
+      month: 'short',
+      year: 'numeric'
+    });
+  };
+
+  // Get last full month (e.g., if today is Oct 7, last full month is Sep)
+  const getLastFullMonth = () => {
+    const lastMonth = subMonths(startOfMonth(new Date()), 1);
+    return format(lastMonth, 'yyyy-MM');
+  };
+
+  const isLastFullMonth = (monthKey: string) => {
+    return monthKey === getLastFullMonth();
+  };
+
+  // Subtle highlight style for last full month following UX best practices
+  const getHighlightStyle = (isHighlighted: boolean, baseColor?: string) => {
+    if (!isHighlighted) return { bgcolor: baseColor || 'inherit' };
+    return {
+      bgcolor: 'rgba(76, 175, 80, 0.15)',
+      borderLeft: '3px solid',
+      borderColor: 'rgb(46, 125, 50)',
+      color: 'rgba(27, 94, 32, 1) !important'
+    };
+  };
+
+  const handleExportCSV = () => {
+    if (!report) return;
+
+    // Build CSV content
+    const rows = [];
+
+    // Header row
+    rows.push(['Category', ...report.months.map(m => formatMonth(m.month)), '6-Mo Avg']);
+
+    // Income section
+    rows.push(['INCOME']);
+    const incomeCategories = getIncomeCategories(report);
+    incomeCategories.forEach(category => {
+      const row = [
+        category,
+        ...report.months.map(m => m.incomeByCategory[category] || 0),
+        report.months.reduce((sum, m) => sum + (m.incomeByCategory[category] || 0), 0) / report.months.length
+      ];
+      rows.push(row);
+    });
+    rows.push([
+      'Total Income',
+      ...report.months.map(m => m.totalIncome),
+      report.sixMonthAverage.totalIncome
+    ]);
+
+    // Expense section
+    rows.push(['EXPENSES']);
+    const expenseCategories = getExpenseCategories(report);
+    expenseCategories.forEach(category => {
+      const row = [
+        category,
+        ...report.months.map(m => m.expensesByCategory[category] || 0),
+        report.months.reduce((sum, m) => sum + (m.expensesByCategory[category] || 0), 0) / report.months.length
+      ];
+      rows.push(row);
+    });
+    rows.push([
+      'Total Expenses',
+      ...report.months.map(m => m.totalExpenses),
+      report.sixMonthAverage.totalExpenses
+    ]);
+
+    // Net income
+    rows.push([
+      'Net Income',
+      ...report.months.map(m => m.netIncome),
+      report.sixMonthAverage.netIncome
+    ]);
+
+    // Convert to CSV string
+    const csvContent = rows.map(row => row.join(',')).join('\n');
+
+    // Download
+    const blob = new Blob([csvContent], { type: 'text/csv' });
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `property-pl-${report.propertyAddress.replace(/[^a-z0-9]/gi, '_')}.csv`;
+    link.click();
+    window.URL.revokeObjectURL(url);
+  };
+
+  if (loading) {
+    return (
+      <Box display="flex" justifyContent="center" p={4}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box p={4}>
+        <Typography color="error">{error}</Typography>
+      </Box>
+    );
+  }
+
+  if (!report || report.months.length === 0) {
+    return (
+      <Box p={4}>
+        <Typography color="text.secondary">
+          No transaction data available for this property.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const incomeCategories = getIncomeCategories(report);
+  const expenseCategories = getExpenseCategories(report);
+
+  return (
+    <Box>
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
+        <Box>
+          <Typography variant="h5" gutterBottom>
+            Property P&L Report
+          </Typography>
+          <Typography variant="subtitle1" color="text.secondary">
+            {report.propertyAddress}
+          </Typography>
+        </Box>
+        <Button
+          variant="outlined"
+          startIcon={<DownloadIcon />}
+          onClick={handleExportCSV}
+        >
+          Export CSV
+        </Button>
+      </Box>
+
+      <Paper sx={{ overflowX: 'auto' }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell><strong>Category</strong></TableCell>
+              {report.months.map(m => (
+                <TableCell
+                  key={m.month}
+                  align="right"
+                  sx={{
+                    ...(isLastFullMonth(m.month) ? {
+                      bgcolor: 'rgb(46, 125, 50) !important',
+                      borderLeft: '3px solid',
+                      borderColor: 'rgb(46, 125, 50)',
+                      fontWeight: 600,
+                      color: 'white !important'
+                    } : {
+                      fontWeight: 400
+                    })
+                  }}
+                >
+                  <strong>{formatMonth(m.month)}</strong>
+                </TableCell>
+              ))}
+              <TableCell align="right">
+                <strong>6-Mo Avg</strong>
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {/* Income Section */}
+            <TableRow>
+              <TableCell colSpan={report.months.length + 2} sx={{ bgcolor: 'grey.100' }}>
+                <strong>INCOME</strong>
+              </TableCell>
+            </TableRow>
+            {incomeCategories.map(category => (
+              <TableRow key={`income-${category}`}>
+                <TableCell sx={{ pl: 4 }}>{category}</TableCell>
+                {report.months.map(m => (
+                  <TableCell
+                    key={m.month}
+                    align="right"
+                    sx={getHighlightStyle(isLastFullMonth(m.month))}
+                  >
+                    {formatCurrency(m.incomeByCategory[category] || 0)}
+                  </TableCell>
+                ))}
+                <TableCell align="right">
+                  {formatCurrency(
+                    report.months.reduce((sum, m) => sum + (m.incomeByCategory[category] || 0), 0) / report.months.length
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+            <TableRow sx={{ bgcolor: 'grey.50' }}>
+              <TableCell><strong>Total Income</strong></TableCell>
+              {report.months.map(m => (
+                <TableCell
+                  key={m.month}
+                  align="right"
+                  sx={{
+                    ...getHighlightStyle(isLastFullMonth(m.month)),
+                    ...(!isLastFullMonth(m.month) && { bgcolor: 'grey.50' })
+                  }}
+                >
+                  <strong>{formatCurrency(m.totalIncome)}</strong>
+                </TableCell>
+              ))}
+              <TableCell align="right">
+                <strong>{formatCurrency(report.sixMonthAverage.totalIncome)}</strong>
+              </TableCell>
+            </TableRow>
+
+            {/* Expenses Section */}
+            <TableRow>
+              <TableCell colSpan={report.months.length + 2} sx={{ bgcolor: 'grey.100' }}>
+                <strong>EXPENSES</strong>
+              </TableCell>
+            </TableRow>
+            {expenseCategories.map(category => (
+              <TableRow key={`expense-${category}`}>
+                <TableCell sx={{ pl: 4 }}>{category}</TableCell>
+                {report.months.map(m => (
+                  <TableCell
+                    key={m.month}
+                    align="right"
+                    sx={getHighlightStyle(isLastFullMonth(m.month))}
+                  >
+                    {formatCurrency(m.expensesByCategory[category] || 0)}
+                  </TableCell>
+                ))}
+                <TableCell align="right">
+                  {formatCurrency(
+                    report.months.reduce((sum, m) => sum + (m.expensesByCategory[category] || 0), 0) / report.months.length
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+            <TableRow sx={{ bgcolor: 'grey.50' }}>
+              <TableCell><strong>Total Expenses</strong></TableCell>
+              {report.months.map(m => (
+                <TableCell
+                  key={m.month}
+                  align="right"
+                  sx={{
+                    ...getHighlightStyle(isLastFullMonth(m.month)),
+                    ...(!isLastFullMonth(m.month) && { bgcolor: 'grey.50' })
+                  }}
+                >
+                  <strong>{formatCurrency(m.totalExpenses)}</strong>
+                </TableCell>
+              ))}
+              <TableCell align="right">
+                <strong>{formatCurrency(report.sixMonthAverage.totalExpenses)}</strong>
+              </TableCell>
+            </TableRow>
+
+            {/* Net Income */}
+            <TableRow>
+              <TableCell><strong>Net Income</strong></TableCell>
+              {report.months.map(m => (
+                <TableCell
+                  key={m.month}
+                  align="right"
+                  sx={getHighlightStyle(isLastFullMonth(m.month))}
+                >
+                  <strong style={{ color: m.netIncome >= 0 ? 'green' : 'red' }}>
+                    {formatCurrency(m.netIncome)}
+                  </strong>
+                </TableCell>
+              ))}
+              <TableCell align="right">
+                <strong style={{ color: report.sixMonthAverage.netIncome >= 0 ? 'green' : 'red' }}>
+                  {formatCurrency(report.sixMonthAverage.netIncome)}
+                </strong>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </Paper>
+    </Box>
+  );
+};

--- a/src/pages/PropertyDetailsPage.tsx
+++ b/src/pages/PropertyDetailsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import { Box, Typography, Paper, Button, Chip, Card, TextField, Dialog, DialogTitle, DialogContent, DialogActions, List, ListItem, ListItemText, IconButton, Tooltip, Link as MuiLink, Divider, Snackbar, Alert, Avatar, Select, MenuItem, FormControl, InputLabel, Accordion, AccordionSummary, AccordionDetails } from '@mui/material';
 import * as Icons from '@mui/icons-material';
 import { Property, Note, Link as PropertyLink, CreateNote, CreateLink, Contact } from '../types/property';
@@ -341,6 +341,22 @@ const PropertyDetailsPage: React.FC = () => {
             }}
           >
             Edit
+          </Button>
+          <Button
+            component={Link}
+            to={`/reports/property-pl/${property.id}`}
+            variant="outlined"
+            startIcon={<Icons.Assessment />}
+            size="small"
+            sx={{
+              flex: 1,
+              maxWidth: { sm: '200px' },
+              borderRadius: 2,
+              py: 0.5,
+              fontSize: '0.875rem'
+            }}
+          >
+            P&L Report
           </Button>
           <ShareReportButton
             property={property}

--- a/src/pages/PropertyPLReportPage.tsx
+++ b/src/pages/PropertyPLReportPage.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Container, Box } from '@mui/material';
+import { useParams } from 'react-router-dom';
+import { PropertyPLReport } from '../components/Reports/PropertyPLReport';
+
+export const PropertyPLReportPage: React.FC = () => {
+  const { propertyId } = useParams<{ propertyId: string }>();
+
+  if (!propertyId) {
+    return <div>Property ID required</div>;
+  }
+
+  return (
+    <Container maxWidth="lg">
+      <Box py={4}>
+        <PropertyPLReport propertyId={propertyId} />
+      </Box>
+    </Container>
+  );
+};

--- a/src/utils/__tests__/reportUtils.test.ts
+++ b/src/utils/__tests__/reportUtils.test.ts
@@ -1,0 +1,326 @@
+import {
+  generatePropertyPLReport,
+  getIncomeCategories,
+  getExpenseCategories
+} from '../reportUtils';
+import { Transaction } from '../../types/transaction';
+import { format, subMonths } from 'date-fns';
+
+describe('reportUtils', () => {
+  const mockPropertyId = 'prop-123';
+  const mockPropertyAddress = '123 Main St';
+
+  const createMockTransaction = (
+    amount: number,
+    category: string,
+    date: string,
+    overrideDate?: string
+  ): Transaction => ({
+    id: `trans-${Math.random()}`,
+    date,
+    amount,
+    category,
+    propertyId: mockPropertyId,
+    expenseType: 'Operating',
+    overrideDate,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  });
+
+  describe('generatePropertyPLReport', () => {
+    it('should generate report with income and expenses', () => {
+      const currentDate = new Date();
+      const lastMonth = format(subMonths(currentDate, 1), 'yyyy-MM-dd');
+
+      const transactions: Transaction[] = [
+        createMockTransaction(1500, 'Rent Income', lastMonth),
+        createMockTransaction(-500, 'Maintenance', lastMonth),
+        createMockTransaction(-300, 'Utilities', lastMonth)
+      ];
+
+      const report = generatePropertyPLReport(
+        transactions,
+        mockPropertyId,
+        mockPropertyAddress,
+        6
+      );
+
+      expect(report.propertyId).toBe(mockPropertyId);
+      expect(report.propertyAddress).toBe(mockPropertyAddress);
+      expect(report.months).toHaveLength(6);
+
+      // Check last month has data
+      const lastMonthKey = format(subMonths(currentDate, 1), 'yyyy-MM');
+      const lastMonthData = report.months.find(m => m.month === lastMonthKey);
+
+      expect(lastMonthData).toBeDefined();
+      expect(lastMonthData!.totalIncome).toBe(1500);
+      expect(lastMonthData!.totalExpenses).toBe(800);
+      expect(lastMonthData!.netIncome).toBe(700);
+    });
+
+    it('should handle override dates correctly', () => {
+      const currentDate = new Date();
+      const twoMonthsAgo = format(subMonths(currentDate, 2), 'yyyy-MM-dd');
+      const lastMonth = format(subMonths(currentDate, 1), 'yyyy-MM-dd');
+
+      // Transaction dated 2 months ago but overridden to last month
+      const transactions: Transaction[] = [
+        createMockTransaction(1000, 'Rent Income', twoMonthsAgo, lastMonth)
+      ];
+
+      const report = generatePropertyPLReport(
+        transactions,
+        mockPropertyId,
+        mockPropertyAddress,
+        6
+      );
+
+      const lastMonthKey = format(subMonths(currentDate, 1), 'yyyy-MM');
+      const lastMonthData = report.months.find(m => m.month === lastMonthKey);
+
+      // Should appear in last month due to override date
+      expect(lastMonthData!.totalIncome).toBe(1000);
+
+      // Should NOT appear in 2 months ago
+      const twoMonthsAgoKey = format(subMonths(currentDate, 2), 'yyyy-MM');
+      const twoMonthsAgoData = report.months.find(m => m.month === twoMonthsAgoKey);
+      expect(twoMonthsAgoData!.totalIncome).toBe(0);
+    });
+
+    it('should filter to operational expenses only', () => {
+      const currentDate = new Date();
+      const lastMonth = format(subMonths(currentDate, 1), 'yyyy-MM-dd');
+
+      const transactions: Transaction[] = [
+        { ...createMockTransaction(-500, 'Repair', lastMonth), expenseType: 'Operating' },
+        { ...createMockTransaction(-5000, 'Renovation', lastMonth), expenseType: 'Capital' }
+      ];
+
+      const report = generatePropertyPLReport(
+        transactions,
+        mockPropertyId,
+        mockPropertyAddress,
+        6
+      );
+
+      const lastMonthKey = format(subMonths(currentDate, 1), 'yyyy-MM');
+      const lastMonthData = report.months.find(m => m.month === lastMonthKey);
+
+      // Only operational expense should be included
+      expect(lastMonthData!.totalExpenses).toBe(500);
+    });
+
+    it('should filter to specific property only', () => {
+      const currentDate = new Date();
+      const lastMonth = format(subMonths(currentDate, 1), 'yyyy-MM-dd');
+
+      const transactions: Transaction[] = [
+        createMockTransaction(1000, 'Rent', lastMonth), // propertyId: prop-123
+        { ...createMockTransaction(2000, 'Rent', lastMonth), propertyId: 'prop-456' }
+      ];
+
+      const report = generatePropertyPLReport(
+        transactions,
+        mockPropertyId,
+        mockPropertyAddress,
+        6
+      );
+
+      const lastMonthKey = format(subMonths(currentDate, 1), 'yyyy-MM');
+      const lastMonthData = report.months.find(m => m.month === lastMonthKey);
+
+      // Only this property's income should be included
+      expect(lastMonthData!.totalIncome).toBe(1000);
+    });
+
+    it('should group transactions by category', () => {
+      const currentDate = new Date();
+      const lastMonth = format(subMonths(currentDate, 1), 'yyyy-MM-dd');
+
+      const transactions: Transaction[] = [
+        createMockTransaction(1500, 'Rent Income', lastMonth),
+        createMockTransaction(500, 'Parking Income', lastMonth),
+        createMockTransaction(-300, 'Utilities', lastMonth),
+        createMockTransaction(-200, 'Maintenance', lastMonth),
+        createMockTransaction(-100, 'Maintenance', lastMonth) // Same category
+      ];
+
+      const report = generatePropertyPLReport(
+        transactions,
+        mockPropertyId,
+        mockPropertyAddress,
+        6
+      );
+
+      const lastMonthKey = format(subMonths(currentDate, 1), 'yyyy-MM');
+      const lastMonthData = report.months.find(m => m.month === lastMonthKey);
+
+      expect(lastMonthData!.incomeByCategory['Rent Income']).toBe(1500);
+      expect(lastMonthData!.incomeByCategory['Parking Income']).toBe(500);
+      expect(lastMonthData!.expensesByCategory['Utilities']).toBe(300);
+      expect(lastMonthData!.expensesByCategory['Maintenance']).toBe(300); // 200 + 100
+    });
+
+    it('should calculate 6-month averages correctly', () => {
+      const currentDate = new Date();
+      const transactions: Transaction[] = [];
+
+      // Add transactions for 3 months: 1000, 2000, 3000 income
+      for (let i = 1; i <= 3; i++) {
+        const monthDate = format(subMonths(currentDate, i), 'yyyy-MM-dd');
+        transactions.push(createMockTransaction(i * 1000, 'Rent', monthDate));
+        transactions.push(createMockTransaction(-i * 100, 'Utilities', monthDate));
+      }
+
+      const report = generatePropertyPLReport(
+        transactions,
+        mockPropertyId,
+        mockPropertyAddress,
+        6
+      );
+
+      // Average income: (1000 + 2000 + 3000 + 0 + 0 + 0) / 6 = 1000
+      expect(report.sixMonthAverage.totalIncome).toBe(1000);
+
+      // Average expenses: (100 + 200 + 300 + 0 + 0 + 0) / 6 = 100
+      expect(report.sixMonthAverage.totalExpenses).toBe(100);
+
+      // Average net: 1000 - 100 = 900
+      expect(report.sixMonthAverage.netIncome).toBe(900);
+    });
+
+    it('should handle empty transaction list', () => {
+      const report = generatePropertyPLReport(
+        [],
+        mockPropertyId,
+        mockPropertyAddress,
+        6
+      );
+
+      expect(report.months).toHaveLength(6);
+      expect(report.sixMonthAverage.totalIncome).toBe(0);
+      expect(report.sixMonthAverage.totalExpenses).toBe(0);
+      expect(report.sixMonthAverage.netIncome).toBe(0);
+    });
+
+    it('should generate correct number of months', () => {
+      const transactions: Transaction[] = [];
+
+      const report3Months = generatePropertyPLReport(
+        transactions,
+        mockPropertyId,
+        mockPropertyAddress,
+        3
+      );
+
+      const report12Months = generatePropertyPLReport(
+        transactions,
+        mockPropertyId,
+        mockPropertyAddress,
+        12
+      );
+
+      expect(report3Months.months).toHaveLength(3);
+      expect(report12Months.months).toHaveLength(12);
+    });
+  });
+
+  describe('getIncomeCategories', () => {
+    it('should extract unique income categories', () => {
+      const currentDate = new Date();
+      const lastMonth = format(subMonths(currentDate, 1), 'yyyy-MM-dd');
+      const twoMonthsAgo = format(subMonths(currentDate, 2), 'yyyy-MM-dd');
+
+      const transactions: Transaction[] = [
+        createMockTransaction(1500, 'Rent Income', lastMonth),
+        createMockTransaction(500, 'Parking Income', lastMonth),
+        createMockTransaction(1500, 'Rent Income', twoMonthsAgo), // Duplicate category
+        createMockTransaction(300, 'Laundry Income', twoMonthsAgo)
+      ];
+
+      const report = generatePropertyPLReport(
+        transactions,
+        mockPropertyId,
+        mockPropertyAddress,
+        6
+      );
+
+      const categories = getIncomeCategories(report);
+
+      expect(categories).toHaveLength(3);
+      expect(categories).toContain('Rent Income');
+      expect(categories).toContain('Parking Income');
+      expect(categories).toContain('Laundry Income');
+      expect(categories).toEqual(categories.slice().sort()); // Should be sorted
+    });
+
+    it('should return empty array when no income', () => {
+      const currentDate = new Date();
+      const lastMonth = format(subMonths(currentDate, 1), 'yyyy-MM-dd');
+
+      const transactions: Transaction[] = [
+        createMockTransaction(-500, 'Utilities', lastMonth)
+      ];
+
+      const report = generatePropertyPLReport(
+        transactions,
+        mockPropertyId,
+        mockPropertyAddress,
+        6
+      );
+
+      const categories = getIncomeCategories(report);
+      expect(categories).toHaveLength(0);
+    });
+  });
+
+  describe('getExpenseCategories', () => {
+    it('should extract unique expense categories', () => {
+      const currentDate = new Date();
+      const lastMonth = format(subMonths(currentDate, 1), 'yyyy-MM-dd');
+      const twoMonthsAgo = format(subMonths(currentDate, 2), 'yyyy-MM-dd');
+
+      const transactions: Transaction[] = [
+        createMockTransaction(-300, 'Utilities', lastMonth),
+        createMockTransaction(-500, 'Maintenance', lastMonth),
+        createMockTransaction(-300, 'Utilities', twoMonthsAgo), // Duplicate category
+        createMockTransaction(-200, 'Insurance', twoMonthsAgo)
+      ];
+
+      const report = generatePropertyPLReport(
+        transactions,
+        mockPropertyId,
+        mockPropertyAddress,
+        6
+      );
+
+      const categories = getExpenseCategories(report);
+
+      expect(categories).toHaveLength(3);
+      expect(categories).toContain('Utilities');
+      expect(categories).toContain('Maintenance');
+      expect(categories).toContain('Insurance');
+      expect(categories).toEqual(categories.slice().sort()); // Should be sorted
+    });
+
+    it('should return empty array when no expenses', () => {
+      const currentDate = new Date();
+      const lastMonth = format(subMonths(currentDate, 1), 'yyyy-MM-dd');
+
+      const transactions: Transaction[] = [
+        createMockTransaction(1500, 'Rent Income', lastMonth)
+      ];
+
+      const report = generatePropertyPLReport(
+        transactions,
+        mockPropertyId,
+        mockPropertyAddress,
+        6
+      );
+
+      const categories = getExpenseCategories(report);
+      expect(categories).toHaveLength(0);
+    });
+  });
+});

--- a/src/utils/reportUtils.ts
+++ b/src/utils/reportUtils.ts
@@ -1,0 +1,131 @@
+import { Transaction } from '../types/transaction';
+import { format, startOfMonth, subMonths } from 'date-fns';
+
+export interface MonthlyPLData {
+  month: string; // "2025-09" format
+  incomeByCategory: Record<string, number>;
+  expensesByCategory: Record<string, number>;
+  totalIncome: number;
+  totalExpenses: number;
+  netIncome: number;
+}
+
+export interface PropertyPLReport {
+  propertyId: string;
+  propertyAddress: string;
+  months: MonthlyPLData[];
+  sixMonthAverage: {
+    totalIncome: number;
+    totalExpenses: number;
+    netIncome: number;
+  };
+}
+
+/**
+ * Generate property P&L report from transactions
+ */
+export function generatePropertyPLReport(
+  transactions: Transaction[],
+  propertyId: string,
+  propertyAddress: string,
+  months: number = 6
+): PropertyPLReport {
+  // Filter to operational expenses only for this property
+  const filtered = transactions.filter(t =>
+    t.propertyId === propertyId &&
+    t.expenseType === 'Operating'
+  );
+
+  // Get last N months
+  const endDate = new Date();
+  const startDate = subMonths(endDate, months);
+
+  // Group by month using override_date if present, else date
+  const byMonth = new Map<string, Transaction[]>();
+
+  filtered.forEach(transaction => {
+    const reportDate = transaction.overrideDate || transaction.date;
+    const transDate = new Date(reportDate);
+
+    if (transDate >= startDate && transDate <= endDate) {
+      const monthKey = format(transDate, 'yyyy-MM');
+      if (!byMonth.has(monthKey)) {
+        byMonth.set(monthKey, []);
+      }
+      byMonth.get(monthKey)!.push(transaction);
+    }
+  });
+
+  // Generate monthly data
+  const monthlyData: MonthlyPLData[] = [];
+
+  // Create array of last N months
+  for (let i = months - 1; i >= 0; i--) {
+    const monthDate = subMonths(endDate, i);
+    const monthKey = format(startOfMonth(monthDate), 'yyyy-MM');
+    const monthTransactions = byMonth.get(monthKey) || [];
+
+    const incomeByCategory: Record<string, number> = {};
+    const expensesByCategory: Record<string, number> = {};
+    let totalIncome = 0;
+    let totalExpenses = 0;
+
+    monthTransactions.forEach(t => {
+      if (t.amount > 0) {
+        // Income
+        incomeByCategory[t.category] = (incomeByCategory[t.category] || 0) + t.amount;
+        totalIncome += t.amount;
+      } else {
+        // Expense (amount is negative)
+        expensesByCategory[t.category] = (expensesByCategory[t.category] || 0) + Math.abs(t.amount);
+        totalExpenses += Math.abs(t.amount);
+      }
+    });
+
+    monthlyData.push({
+      month: monthKey,
+      incomeByCategory,
+      expensesByCategory,
+      totalIncome,
+      totalExpenses,
+      netIncome: totalIncome - totalExpenses
+    });
+  }
+
+  // Calculate 6-month average
+  const avgIncome = monthlyData.reduce((sum, m) => sum + m.totalIncome, 0) / monthlyData.length;
+  const avgExpenses = monthlyData.reduce((sum, m) => sum + m.totalExpenses, 0) / monthlyData.length;
+
+  return {
+    propertyId,
+    propertyAddress,
+    months: monthlyData,
+    sixMonthAverage: {
+      totalIncome: avgIncome,
+      totalExpenses: avgExpenses,
+      netIncome: avgIncome - avgExpenses
+    }
+  };
+}
+
+/**
+ * Get all unique income categories from report
+ */
+export function getIncomeCategories(report: PropertyPLReport): string[] {
+  const categories = new Set<string>();
+  report.months.forEach(m => {
+    Object.keys(m.incomeByCategory).forEach(cat => categories.add(cat));
+  });
+  return Array.from(categories).sort();
+}
+
+/**
+ * Get all unique expense categories from report
+ */
+export function getExpenseCategories(report: PropertyPLReport): string[] {
+  const categories = new Set<string>();
+  report.months.forEach(m => {
+    Object.keys(m.expensesByCategory).forEach(cat => categories.add(cat));
+  });
+  return Array.from(categories).sort();
+}


### PR DESCRIPTION
## Summary
Adds 6-month P&L report showing income, expenses, and net income by category

## Changes
- Report utilities with transaction aggregation and filtering
- React component with table view and CSV export
- Last full month highlighting for quick insights
- 12 unit tests with 100% statement coverage

## Testing
All tests passing, build verified at 257 kB

🤖 Generated with [Claude Code](https://claude.com/claude-code)